### PR TITLE
🔀 Test : CI/CD 구축 테스트2

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,4 +46,4 @@ jobs:
             fi
             docker stop qup-frontend || true
             docker rm qup-frontend || true
-            docker run -d -p 80:3024 --name qup-frontend ${{ env.DOCKER_IMAGE }}:latest
+            docker run -d -p 3024:80 --name qup-frontend ${{ env.DOCKER_IMAGE }}:latest

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3024,
+    port: 80,
+    host: '0.0.0.0',
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## 🔍 What is the PR?
<!-- PR 내용을 리스트로 작성-->
    <현재 상태>
Dockerfile:
EXPOSE 80: Docker 컨테이너 내부에서 80번 포트를 노출하도록 설정
vite.config.ts:
server: { port: 3024 }: Vite 개발 서버가 3024번 포트에서 실행되도록 설정
EC2 인스턴스의 보안 그룹:
인바운드 규칙에 3024번 포트와 80번 포트에 대한 허용 규칙
3024 포트에 대한 인바운드 트래픽이 0.0.0.0/0으로 설정되어 있어, 모든 IP에서 접근 가능

<문제>
포트 불일치:
Docker 컨테이너의 EXPOSE는 80번 포트로 설정되어 있지만, vite.config.ts에서는 3024번 포트를 사용
이로 인해 컨테이너 내부에서 Vite 서버가 3024번 포트에서 실행되지만, 외부에서는 80번 포트로 노출되고 있어 연결이 실패
포트 매핑 필요:
Docker 컨테이너 실행 시 호스트의 3024번 포트를 컨테이너 내부의 3024번 포트와 매핑해야 합니다.

<해결>
Vite 서버를 80번 포트로 설정
docker run -d -p 3024:80 ~~~ 로 실행
## 📸 Screenshot 
<!-- 작업한 화면의 스크린 샷 -->
    
    
## 🙏 To Reviewers 
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점 -->
    
    
## ✅ Check List
- [ ]  Merge 하는 브랜치가 올바른가?
- [ ]  코딩 컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  내 코드에 대한 자기 검토가 되었는가?
    

## 💭 Related Issues 
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->    
- Resolved: #2